### PR TITLE
jupyter notebook関連の修正

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb filter=lfs diff=lfs merge=lfs -text

--- a/example/helloworld.ipynb
+++ b/example/helloworld.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae70335f275d5989285338c2ad860817dccf2977ff8d922661eeeee792a5b8b7
+size 192509

--- a/selenible/jupyter.py
+++ b/selenible/jupyter.py
@@ -37,6 +37,8 @@ class SelenibleKernel(Kernel):
     def drv(self):
         if self._drv is None:
             drvcls = cli.loadmodules(self.driver_name, self.extensions)
+            self.log.info("driver: cls=%s, name=%s, exts=%s",
+                          drvcls, self.driver_name, self.extensions)
             self._drv = drvcls()
             drvlog = self._drv.log
             self.logio = io.StringIO()
@@ -50,7 +52,8 @@ class SelenibleKernel(Kernel):
 
     def cmd_driver(self, args):
         "set driver: phantom, chrome, firefox, etc..."
-        self.drive_name = args[0]
+        self.log.info("driver: %s -> %s", self.driver_name, args[0])
+        self.driver_name = args[0]
 
     def cmd_module(self, args):
         "load modules"

--- a/selenible/jupyter.py
+++ b/selenible/jupyter.py
@@ -1,5 +1,6 @@
 import io
 import base64
+import shlex
 import inspect
 import yaml
 from PIL import Image
@@ -79,7 +80,7 @@ class SelenibleKernel(Kernel):
     def do_execute(self, code, silent, store_history=True, user_expressions=None,
                    allow_stdin=False):
         if code.startswith("%"):
-            token = code.split()
+            token = shlex.split(code)
             cmd = token[0].lstrip("%")
             args = token[1:]
             if hasattr(self, "cmd_"+cmd):

--- a/selenible/seleniblepiter/kernel.json
+++ b/selenible/seleniblepiter/kernel.json
@@ -1,6 +1,6 @@
 {
   "argv": [
-    "python", "-m", "selenible.seleblepiter", "-f", "{connection_file}"
+    "python", "-m", "selenible.jupyter", "-f", "{connection_file}"
   ],
   "display_name": "Selenible"
 }


### PR DESCRIPTION
- typoの修正
- %コマンド
  - str.split()→shlex.split()
- *.ipynbはlfsにした
  - 以前のhelloworld.ipynbは履歴からも削除
     - スクリーンショットのデータが含まれ、git clone時のダウンロードが大きくなるため
     - 以前のツリーの状態からpullできなくなる。再度cloneし直す必要があるよ